### PR TITLE
Removing outdated resources, improving api-controller responses.

### DIFF
--- a/src/GroupDocs.Viewer.WebForms.csproj
+++ b/src/GroupDocs.Viewer.WebForms.csproj
@@ -134,35 +134,6 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Global.asax" />
-    <Content Include="Resources\common\fonts\fontawesome-webfont.eot" />
-    <Content Include="Resources\common\fonts\fontawesome-webfont.ttf" />
-    <Content Include="Resources\common\fonts\fontawesome-webfont.woff" />
-    <Content Include="Resources\common\fonts\fontawesome-webfont.woff2" />
-    <Content Include="Resources\common\fonts\FontAwesome.otf" />
-    <Content Include="Resources\common\css\circle-progress.css" />
-    <Content Include="Resources\common\css\font-awesome.min.css" />
-    <Content Include="Resources\common\css\images\ui-icons_444444_256x240.png" />
-    <Content Include="Resources\common\css\images\ui-icons_555555_256x240.png" />
-    <Content Include="Resources\common\css\images\ui-icons_777620_256x240.png" />
-    <Content Include="Resources\common\css\images\ui-icons_777777_256x240.png" />
-    <Content Include="Resources\common\css\images\ui-icons_cc0000_256x240.png" />
-    <Content Include="Resources\common\css\images\ui-icons_ffffff_256x240.png" />
-    <Content Include="Resources\common\css\jquery-ui.min.css" />
-    <Content Include="Resources\common\css\swiper.min.css" />
-    <Content Include="Resources\common\fonts\fontawesome-webfont.svg" />
-    <Content Include="Resources\common\images\banner.png" />
-    <Content Include="Resources\common\js\es6-promise.auto.js" />
-    <Content Include="Resources\common\js\jquery-ui.min.js" />
-    <Content Include="Resources\common\js\jquery.initialize.min.js" />
-    <Content Include="Resources\common\js\jquery.min.js" />
-    <Content Include="Resources\common\js\jquery.ui.touch-punch.min.js" />
-    <Content Include="Resources\common\js\swiper.min.js" />
-    <Content Include="Resources\viewer\css\viewer-dark.css" />
-    <Content Include="Resources\viewer\css\viewer-light.css" />
-    <Content Include="Resources\viewer\css\viewer.css" />
-    <Content Include="Resources\viewer\css\viewer.mobile.css" />
-    <Content Include="Resources\viewer\images\logo.png" />
-    <Content Include="Resources\viewer\js\viewer.js" />
     <Content Include="Viewer.aspx" />
     <Content Include="Web.config">
       <SubType>Designer</SubType>

--- a/src/Products/Viewer/Controllers/ViewerApiController.cs
+++ b/src/Products/Viewer/Controllers/ViewerApiController.cs
@@ -129,7 +129,7 @@ namespace GroupDocs.Viewer.WebForms.Products.Viewer.Controllers
             }
             catch (System.Exception ex)
             {
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 
@@ -241,7 +241,7 @@ namespace GroupDocs.Viewer.WebForms.Products.Viewer.Controllers
             catch (System.Exception ex)
             {
                 // set exception message
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 
@@ -336,7 +336,7 @@ namespace GroupDocs.Viewer.WebForms.Products.Viewer.Controllers
             catch (System.Exception ex)
             {
                 // set exception message
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 
@@ -361,7 +361,7 @@ namespace GroupDocs.Viewer.WebForms.Products.Viewer.Controllers
             catch (System.Exception ex)
             {
                 // set exception message
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex, loadDocumentRequest.password));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex, loadDocumentRequest.password));
             }
         }
 
@@ -386,7 +386,7 @@ namespace GroupDocs.Viewer.WebForms.Products.Viewer.Controllers
             catch (System.Exception ex)
             {
                 // set exception message
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 


### PR DESCRIPTION
**Problem:**
We have outdated resources in the project that can confuse user. It would be better to response with `InternalServerError` status from the catch blocks of the api-controller.

**Solution:**
- Outdated resources were removed.
- `OK` status was replaced by `InternalServerError` in the catch blocks of the api-controller.

**Tests:**
Build&run the project, check that it works as expected.