### PR TITLE
Improvements to support feature for running on non-localhost API URL.

### DIFF
--- a/src/Viewer.aspx
+++ b/src/Viewer.aspx
@@ -13,15 +13,15 @@
 </head>
 <body>
     <client-root></client-root>
-    <script src="resources/viewer/runtime-es2015.js" type="module"></script>
-    <script src="resources/viewer/runtime-es5.js" nomodule></script>
-    <script src="resources/viewer/polyfills-es2015.js" type="module"></script>
-    <script src="resources/viewer/polyfills-es5.js" nomodule></script>
-    <script src="resources/viewer/styles-es2015.js" type="module"></script>
-    <script src="resources/viewer/styles-es5.js" nomodule></script>
-    <script src="resources/viewer/vendor-es2015.js" type="module"></script>
-    <script src="resources/viewer/vendor-es5.js" nomodule></script>
-    <script src="resources/viewer/main-es2015.js" type="module"></script>
-    <script src="resources/viewer/main-es5.js" nomodule></script>
+    <script src="/viewer/resources/viewer/runtime-es2015.js" type="module"></script>
+    <script src="/viewer/resources/viewer/runtime-es5.js" nomodule></script>
+    <script src="/viewer/resources/viewer/polyfills-es2015.js" type="module"></script>
+    <script src="/viewer/resources/viewer/polyfills-es5.js" nomodule></script>
+    <script src="/viewer/resources/viewer/styles-es2015.js" type="module"></script>
+    <script src="/viewer/resources/viewer/styles-es5.js" nomodule></script>
+    <script src="/viewer/resources/viewer/vendor-es2015.js" type="module"></script>
+    <script src="/viewer/resources/viewer/vendor-es5.js" nomodule></script>
+    <script src="/viewer/resources/viewer/main-es2015.js" type="module"></script>
+    <script src="/viewer/resources/viewer/main-es5.js" nomodule></script>
 </body>
 </html>

--- a/src/client/apps/viewer/src/app/app.module.ts
+++ b/src/client/apps/viewer/src/app/app.module.ts
@@ -7,7 +7,7 @@ import { ViewerModule } from "@groupdocs.examples.angular/viewer";
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule,
-    ViewerModule],
+    ViewerModule.forRoot("http://localhost:8080")],
   providers: [],
   bootstrap: [AppComponent]
 })


### PR DESCRIPTION
1. Was added implicit default option to use `localhost:8080` URL by default (as in other apps, and as it is mentioned in p.3. in  following instruction https://products.conholdate.app/viewer/view/59mhVoboa6I5O4DL3/using-custom-host-url-step-by-step-guide.docx?preview=true.pdf).
2. Updated paths to the build js-resources.

Related PR: https://github.com/groupdocs-total/GroupDocs.Total-Angular/pull/241.